### PR TITLE
allow passing through a string for `:filter` that's already in "k1:v1 k2:v2" format

### DIFF
--- a/lib/pivotal_tracker.rb
+++ b/lib/pivotal_tracker.rb
@@ -75,7 +75,7 @@ class PivotalTracker
   
   def get_all_project_stories(project_id, options = {})
     if options[:filter]
-      options[:filter] = options[:filter].inject([]) {|f,(key,value)| f << "#{key}:#{value}"}.join(' ')
+      options[:filter] = options[:filter].map {|k,v| v ? "#{k}:#{v}" : k }.join(' ')
     end
 
     response = self.class.get("/projects/#{project_id}/stories", :query => options)

--- a/spec/pivotal_tracker_spec.rb
+++ b/spec/pivotal_tracker_spec.rb
@@ -138,6 +138,12 @@ describe PivotalTracker do
         stories.first.owned_by.should == 'Montgomery Scott'
       end
       
+      it "should get all stories for a project based on a given filter string" do
+        stub_get("/projects/1/stories\?filter=awesome%20type%3Afeature", 'stories.xml')
+        stories = @tracker.get_all_project_stories(1, :filter => 'awesome type:feature')
+        stories.first.owned_by.should == 'Montgomery Scott'
+      end
+
       it "should get all stories for a project paginated by a limit and offset" do
         stub_get("/projects/1/stories\?limit=10&offset=20", 'stories.xml')
         stories = @tracker.get_all_project_stories(1, :limit => 10, :offset => 20)


### PR DESCRIPTION
mostly, I want to be able to combine a search string along with the structured key/value tokens.
